### PR TITLE
pp_split_page_results bugfix: correct variable name

### DIFF
--- a/includes/classes/pp_split_page_results.php
+++ b/includes/classes/pp_split_page_results.php
@@ -27,7 +27,7 @@ class splitPageResults extends base
         
         $this->input_page_suffix = 1;
         $this->input_pagecount_suffix = 1;
-        $this->hidden_input_added = false;
+        $this->hidden_var_added = false;
         
         // -----
         // If the plugin has been configured to provide an items-per-page dropdown ...


### PR DESCRIPTION
see https://github.com/lat9/product_pagination/issues/17

Note, updated to change 'fixes' to 'see' so that the issue remains open until part of a release.